### PR TITLE
fix deprecated code source comment typos

### DIFF
--- a/deprecated/_dep_curve_tracker.py
+++ b/deprecated/_dep_curve_tracker.py
@@ -97,7 +97,7 @@ class CurveTracker(WireTracker):
         Override base event
         """
 
-        #internal tracker visiblity criteria:
+        #internal tracker visibility criteria:
         # 1. curve must be the mouse component
         # 2. selection state must be manual
 
@@ -159,7 +159,7 @@ class CurveTracker(WireTracker):
 
     def _set_internal_visiblity(self, is_visible):
         """
-        Set the visiblity of the internal curve geometry
+        Set the visibility of the internal curve geometry
         """
 
         self.wire_tracker.set_visibility(is_visible)
@@ -610,7 +610,7 @@ class CurveTracker(WireTracker):
     def validate(self, lt_tan=0.0, rt_tan=0.0):
         """
         Validate the arc's tangents against it's PI's
-        points - the corodinates of the three PI nodes
+        points - the coordinates of the three PI nodes
         lt_tan, rt_tan - the length of the tangents of adjoining curves
         """
 

--- a/deprecated/alignment_tracker.py
+++ b/deprecated/alignment_tracker.py
@@ -211,7 +211,7 @@ class AlignmentTracker(BaseTracker, Publisher):
 
     def end_drag(self):
         """
-        Override base fucntion
+        Override base function
         """
 
         super().end_drag()
@@ -292,7 +292,7 @@ class AlignmentTracker(BaseTracker, Publisher):
 
     def _signalize_trackers(self):
         """
-        Regsiter trackers appropriately as subscribers to one another
+        Register trackers appropriately as subscribers to one another
         """
 
         #subscribe node trackers to alignment and vice-versa

--- a/deprecated/curve_tracker.py
+++ b/deprecated/curve_tracker.py
@@ -97,7 +97,7 @@ class CurveTracker(WireTracker):
         Override base event
         """
 
-        #internal tracker visiblity criteria:
+        #internal tracker visibility criteria:
         # 1. curve must be the mouse component
         # 2. selection state must be manual
 
@@ -160,7 +160,7 @@ class CurveTracker(WireTracker):
 
     def _set_internal_visiblity(self, is_visible):
         """
-        Set the visiblity of the internal curve geometry
+        Set the visibility of the internal curve geometry
         """
 
         self.wire_tracker.set_visibility(is_visible)
@@ -614,7 +614,7 @@ class CurveTracker(WireTracker):
     def validate(self, lt_tan=0.0, rt_tan=0.0):
         """
         Validate the arc's tangents against it's PI's
-        points - the corodinates of the three PI nodes
+        points - the coordinates of the three PI nodes
         lt_tan, rt_tan - the length of the tangents of adjoining curves
         """
 


### PR DESCRIPTION
So they shtop showing up in codespell results (Even though we could just flag not search the deprecated/ directory.